### PR TITLE
add "startup" flag to @service

### DIFF
--- a/src/selva/di/decorator.py
+++ b/src/selva/di/decorator.py
@@ -26,7 +26,12 @@ def _is_inject(value) -> bool:
 
 @dataclass_transform(eq_default=False)
 def service(
-    injectable: T = None, /, *, provides: type = None, name: str = None
+    injectable: T = None,
+    /,
+    *,
+    provides: type = None,
+    name: str = None,
+    startup: bool = False,
 ) -> T | Callable[[T], T]:
     """Declare a class or function as a service
 
@@ -35,7 +40,9 @@ def service(
     """
 
     def inner(inner_injectable: InjectableType) -> T:
-        setattr(inner_injectable, DI_ATTRIBUTE_SERVICE, ServiceInfo(provides, name))
+        setattr(
+            inner_injectable, DI_ATTRIBUTE_SERVICE, ServiceInfo(provides, name, startup)
+        )
 
         if inspect.isclass(inner_injectable):
             dependencies = [

--- a/src/selva/di/service/model.py
+++ b/src/selva/di/service/model.py
@@ -8,6 +8,7 @@ InjectableType = type | FunctionType
 class ServiceInfo(NamedTuple):
     provides: type | None
     name: str | None
+    startup: bool = False
 
 
 class ServiceDependency(NamedTuple):

--- a/src/selva/ext/data/redis/settings.py
+++ b/src/selva/ext/data/redis/settings.py
@@ -1,5 +1,5 @@
 from types import NoneType
-from typing import Self, Type, Literal
+from typing import Literal, Self, Type
 
 from pydantic import BaseModel, ConfigDict, model_serializer, model_validator
 from redis import RedisError

--- a/src/selva/web/application.py
+++ b/src/selva/web/application.py
@@ -134,6 +134,7 @@ class Selva:
             self.handler = chain
 
     async def _lifespan_startup(self):
+        await self.di._run_startup()
         await self._initialize_extensions()
         await self._initialize_middleware()
 

--- a/tests/di/test_startup.py
+++ b/tests/di/test_startup.py
@@ -1,0 +1,35 @@
+import pytest
+
+from selva.di import service, Container
+
+
+@pytest.fixture
+def service_class():
+    class ServiceClass:
+        startup_called = False
+
+        def initialize(self):
+            ServiceClass.startup_called = not ServiceClass.startup_called
+
+    return ServiceClass
+
+
+@pytest.fixture
+def service_factory(service_class):
+    def service_factory() -> service_class:
+        service_class.startup_called = not service_class.startup_called
+        return service_class()
+
+    return service_factory
+
+
+async def test_startup_class(ioc: Container, service_class):
+    ioc.register(service_class, startup=True)
+    await ioc._run_startup()
+    assert service_class.startup_called
+
+
+async def test_startup_factory(ioc: Container, service_class, service_factory):
+    ioc.register(service_factory, startup=True)
+    await ioc._run_startup()
+    assert service_class.startup_called

--- a/tests/web/application/test_service_startup.py
+++ b/tests/web/application/test_service_startup.py
@@ -1,0 +1,26 @@
+from selva.configuration.defaults import default_settings
+from selva.configuration.settings import Settings
+from selva.di import service
+from selva.web.application import Selva
+
+
+async def test_application():
+    @service(startup=True)
+    class Service:
+        startup_called = False
+
+        def initialize(self):
+            Service.startup_called = True
+
+    settings = Settings(
+        default_settings | {
+            "application": f"{__package__}.application",
+        }
+    )
+
+    app = Selva(settings)
+    app.di.service(Service)
+
+    await app._lifespan_startup()
+
+    assert Service.startup_called


### PR DESCRIPTION
"startup" flag indicates that a service is created and initialized on application startup, instead of being created on demand